### PR TITLE
fix keras layer naming (: is not a valid name for keras layer)

### DIFF
--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -139,6 +139,7 @@ def onnx_to_keras(onnx_model, input_names,
                 postfix = node_index if len(node.output) == 1 else "%s_%s" % (node_index, output_index)
                 keras_names.append('LAYER_%s' % postfix)
             else:
+                output = output.replace(":", "_")
                 keras_names.append(output)
 
         if len(node.output) != 1:


### PR DESCRIPTION
This PR is fixing a naming problem causing the building of Keras layers to fail.
In TensorFlow Keras the char ":" is not supported for name so we are converting it to the char "_" instead