### PR TITLE
Change zero initializers to default keras init

### DIFF
--- a/onnx2kerastl/convolution_layers.py
+++ b/onnx2kerastl/convolution_layers.py
@@ -65,7 +65,6 @@ def convert_conv(node, params, layers, lambda_func, node_name, keras_name):
             use_bias=has_bias,
             activation=None,
             dilation_rate=dilation,
-            bias_initializer='zeros', kernel_initializer='zeros',
             name=keras_name,
             groups=n_groups
         )
@@ -111,7 +110,6 @@ def convert_conv(node, params, layers, lambda_func, node_name, keras_name):
                 depth_multiplier=1,
                 weights=weights,
                 dilation_rate=dilation,
-                bias_initializer='zeros', kernel_initializer='zeros',
                 name=keras_name
             )
             layers[node_name] = conv(input_0)
@@ -170,7 +168,6 @@ def convert_conv(node, params, layers, lambda_func, node_name, keras_name):
                 use_bias=has_bias,
                 activation=None,
                 dilation_rate=dilation,
-                bias_initializer='zeros', kernel_initializer='zeros',
                 name=keras_name
             )
 
@@ -285,7 +282,6 @@ def convert_convtranspose(node, params, layers,
             use_bias=has_bias,
             activation=None,
             dilation_rate=dilation,
-            bias_initializer='zeros', kernel_initializer='zeros',
             name=keras_name
         )
 

--- a/onnx2kerastl/linear_layers.py
+++ b/onnx2kerastl/linear_layers.py
@@ -39,7 +39,7 @@ def convert_gemm(node, params, layers, lambda_func, node_name, keras_name):
     if is_numpy(keras_weights[0]):
         dense = keras.layers.Dense(
             output_channels,
-            weights=keras_weights, name=keras_name, bias_initializer='zeros', kernel_initializer='zeros', use_bias=has_bias
+            weights=keras_weights, name=keras_name, use_bias=has_bias
         )
 
         # The first input - always X


### PR DESCRIPTION
In this PR we change the `zeros` initializers set in convolutional layers and dense layers to their default initializer.
I don't see any good reason why the original author specifically had set his initializers on `zeros`, please tell me if you do see the point in that. 
I can say that In his case it doesn’t matter as he is loading the weights for every layer and for us it matters as we also want to train new models from that model structure.