### PR TITLE
Add reduce mean operation

### DIFF
--- a/onnx2kerastl/customonnxlayer/onnxreducemean.py
+++ b/onnx2kerastl/customonnxlayer/onnxreducemean.py
@@ -1,0 +1,24 @@
+from typing import List
+
+import keras.backend as K
+from keras.layers import Layer
+
+
+class OnnxReduceMean(Layer):
+    def __init__(self, axes: List[int], keepdims: bool = True, **kwargs):
+        super().__init__(**kwargs)
+        self.axes = axes
+        self.keepdims = keepdims
+
+
+    def call(self, inputs, **kwargs):
+        tensor = K.mean(inputs, keepdims=self.keepdims, axis=self.axes)
+        return tensor
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "axes": self.axes,
+            "keepdims": self.keepdims,
+        })
+        return config

--- a/onnx2kerastl/operation_layers.py
+++ b/onnx2kerastl/operation_layers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict, Any
 
 import numpy as np
 from tensorflow import keras
@@ -142,6 +143,22 @@ def convert_reduce_mean(node, params, layers, lambda_func, node_name, keras_name
     axes = params['axes']
     reduce_mean_layer = OnnxReduceMean(axes=axes, keepdims=keepdims)
 
+    axes_for_last = [a - 1 for a in axes]
+    if 0 in axes:
+        axes_for_last.remove(0)
+        rank = len(input_0.shape)
+        axes_for_last.append(rank)
+
+    def get_special_data_format_handler():
+        def handle_axis_change(target_data_format: str, config: Dict[str, Any]) -> Dict[str, Any]:
+            if target_data_format == "channels_last":
+                config["axes"] = axes_for_last
+
+            return config
+
+        return handle_axis_change
+
+    reduce_mean_layer.get_special_data_format_handler = get_special_data_format_handler
     layers[node_name] = reduce_mean_layer(input_0)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -205,7 +205,7 @@ python-versions = "*"
 
 [[package]]
 name = "keras-data-format-converter"
-version = "0.0.8"
+version = "0.0.9"
 description = "Generates equal keras models with the desired data format"
 category = "main"
 optional = false
@@ -679,7 +679,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "e42575ddfad1e6cc69c969de669feb81882cf1b0a78a23474afee0ce35629d54"
+content-hash = "0469e28391d262c1122349b857c2bdb591a36b9ab659aa9eb96fc33fc5be0942"
 
 [metadata.files]
 absl-py = [
@@ -825,8 +825,8 @@ keras = [
     {file = "keras-2.9.0-py2.py3-none-any.whl", hash = "sha256:55911256f89cfc9343c9fbe4b61ec45a2d33d89729cbe1ab9dcacf8b07b8b6ab"},
 ]
 keras-data-format-converter = [
-    {file = "keras-data-format-converter-0.0.8.tar.gz", hash = "sha256:d222fb66c88c7abcb970d9d95b56ff878b9cac57210906356a6d58672fe2ed7d"},
-    {file = "keras_data_format_converter-0.0.8-py3-none-any.whl", hash = "sha256:785cc367e5a6dd138350a2935e18564b12873014357bbb271a935eeaff3c668b"},
+    {file = "keras-data-format-converter-0.0.9.tar.gz", hash = "sha256:55841f9e9c8b3f2b4c2a95447dccee02e57df10e067f3f2fc4e08ec2a4b2bb9d"},
+    {file = "keras_data_format_converter-0.0.9-py3-none-any.whl", hash = "sha256:ed48d8b6b5802d20233aecedec40e876cb09378b1938ca12cd856c3b361244a7"},
 ]
 keras-preprocessing = [
     {file = "Keras_Preprocessing-1.1.2-py2.py3-none-any.whl", hash = "sha256:7b82029b130ff61cc99b55f3bd27427df4838576838c5b2f65940e4fcec99a7b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = ">=3.8, <3.11"
 tensorflow = "^2.8"
 tensorflow-addons = "^0.16.1"
 onnx = "^1.11.0"
-keras-data-format-converter = "^0.0.8"
+keras-data-format-converter = "0.0.9"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
This PR is adding a new custom onnx layer  for reduce mean.
This layer will act differently in channel first vs last because it has `axes` parameter that set on what axes should we run the reduce mean operation, hence when converting this layer from channel first to last axes parameter should change accordingly.
Thats why we added the `get_config_for_channel_last` function that helps our converter to build that layer in its channel last form