### PR TITLE
Fix maxpool

### DIFF
--- a/test/layers/poolings/test_maxpool3d_ceil.py
+++ b/test/layers/poolings/test_maxpool3d_ceil.py
@@ -1,0 +1,35 @@
+import numpy as np
+import torch.nn as nn
+import pytest
+import tensorflow as tf
+
+from test.utils import convert_and_test
+
+
+class LayerTest(nn.Module):
+    def __init__(self,  kernel_size=3, stride=1):
+        super(LayerTest, self).__init__()
+        self.pool = nn.MaxPool3d(kernel_size=kernel_size, stride=stride, ceil_mode=True)
+
+    def forward(self, x):
+        x = self.pool(x)
+        return x
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('change_ordering', [True])
+@pytest.mark.parametrize('kernel_size', [3])
+@pytest.mark.parametrize('padding', [1])
+@pytest.mark.parametrize('stride', [2])
+def test_maxpool3d(change_ordering, kernel_size, padding, stride):
+    if not tf.test.gpu_device_name() and not change_ordering:
+        pytest.skip("Skip! Since tensorflow MaxPoolingOp op currently only supports the NHWC tensor format on the CPU")
+    if padding > kernel_size / 2:
+        # RuntimeError: invalid argument 2: pad should be smaller than half of kernel size,
+        # but got padW = 1, padH = 1, kW = 1,
+        pytest.skip("pad should be smaller than half of kernel size")
+    model = LayerTest(kernel_size=kernel_size, padding=padding, stride=stride)
+    model.eval()
+
+    input_np = np.random.uniform(0, 1, (1, 3, 19, 224, 224))
+    error = convert_and_test(model, input_np, verbose=False, change_ordering=change_ordering)

--- a/test/models/test_googlenet.py
+++ b/test/models/test_googlenet.py
@@ -7,11 +7,10 @@ from torchvision.models import googlenet
 
 @pytest.mark.slow
 @pytest.mark.parametrize('pretrained', [True])
-@pytest.mark.skip(reason="Fails on CI init")
 def test_googlenet(pretrained):
     np.random.seed(seed=NP_SEED)
     model = googlenet(pretrained=pretrained)
     model.eval()
 
     input_np = np.random.uniform(0, 1, (1, 3, 224, 224))
-    error = convert_and_test(model, input_np, verbose=False, should_transform_inputs=True)
+    error = convert_and_test(model, input_np, verbose=False, should_transform_inputs=True, epsilon=1.5*10**(-5))

--- a/test/models/test_squeezenet.py
+++ b/test/models/test_squeezenet.py
@@ -8,7 +8,6 @@ from torchvision.models import squeezenet1_0
 @pytest.mark.slow
 @pytest.mark.parametrize('model_class', [squeezenet1_0])
 @pytest.mark.parametrize('pretrained', [True])
-@pytest.mark.skip(reason="Fails on CI init")
 def test_squeezenet(pretrained, model_class):
     np.random.seed(seed=NP_SEED)
     model = model_class(pretrained=pretrained)


### PR DESCRIPTION
MaxPool was missing a ceil_mode param to correctly convert from PyTorch. This cause `GoogleNet` and `SqueezeNet` test to fail.