### PR TITLE
Upgrade to TF 2.21/Keras 3 + ONNX 1.21 + Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
         os: [ubuntu-24.04]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: '3.13'
       #---------------------------#
       - name: Compute Cache Key (Ignoring Only [tool.poetry] version)
         id: compute-cache-key
@@ -61,12 +61,12 @@ jobs:
     name: test-${{ matrix.pytest_target }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: '3.13'
       - name: Install Poetry in Test Job
         uses: snok/install-poetry@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHONPATH := .
-POETRY_MODULE := PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python poetry run python -m
+POETRY_MODULE := poetry run python -m
 PYTEST := $(POETRY_MODULE) pytest
 
 .PHONY: run_tests
@@ -9,7 +9,7 @@ run_tests:
 
 .PHONY: poetry_update
 poetry_update:
-	PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python poetry update
+	poetry update
 
 .PHONY: test_models
 test_models:

--- a/onnx2kerastl/constant_layers.py
+++ b/onnx2kerastl/constant_layers.py
@@ -2,7 +2,7 @@ import numpy as np
 import tensorflow as tf
 from .utils import is_numpy
 from .tfops_funcs import tf_cast, tf_one_hot
-from keras import backend as K
+import keras
 
 def convert_constant(node, params, layers, lambda_func, node_name, keras_name):
     """
@@ -25,7 +25,7 @@ def convert_constant_of_shape(node, params, layers, lambda_func, node_name, kera
 
     input_0 = layers[node.input[0]]
 
-    if not is_numpy(input_0) and not isinstance(input_0, list) and K.is_keras_tensor(input_0):
+    if not is_numpy(input_0) and not isinstance(input_0, list) and isinstance(input_0, keras.KerasTensor):
         # Boolean case
         if value.dtype == np.bool_:
             layers[node_name] = tf.fill(layers[node.input[0]], tf.constant(value.item(), dtype=tf.bool))

--- a/onnx2kerastl/convolution_layers.py
+++ b/onnx2kerastl/convolution_layers.py
@@ -470,7 +470,7 @@ def convert_conv(node, params, layers, lambda_func, node_name, keras_name):
 
         if padding:
             # find the dimension to pad and use the exact padding values
-            input_shape = np.asarray(keras.backend.int_shape(input_0))
+            input_shape = np.asarray(input_0.shape)
             partitioned_dim = np.argwhere(input_shape == channels * n_groups)[0][0]
             padding_dim = 2 if partitioned_dim == 1 else 1
             tf_padding = np.zeros((2, len(input_shape))).astype(int)
@@ -482,7 +482,7 @@ def convert_conv(node, params, layers, lambda_func, node_name, keras_name):
         partial_conv = partial(keras.layers.Conv1D, **conv_args)
         res = permute_wrap_conv_if_constant(partial_conv, input_0, is_constant, weights[0].shape[-2]*n_groups, params)
         if has_bias:
-            res_shape = np.asarray(keras.backend.int_shape(res))
+            res_shape = np.asarray(res.shape)
             bias_dim = np.argwhere(res_shape == bias.shape)[0][0]
             expanded_dims = [dim for dim in range(len(res_shape)) if dim != bias_dim]
             res = res + np.expand_dims(bias, expanded_dims)

--- a/onnx2kerastl/customonnxlayer/onnxeinsum.py
+++ b/onnx2kerastl/customonnxlayer/onnxeinsum.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, List
 
-from keras.layers import Layer, TFOpLambda
+from keras.layers import Layer
 import tensorflow as tf
 import numpy as np
 

--- a/onnx2kerastl/operation_layers.py
+++ b/onnx2kerastl/operation_layers.py
@@ -348,7 +348,7 @@ def convert_split(node, params, layers, lambda_func, node_name, keras_names):
                 splits = [layers[node.input[0]].shape[axis] // 2] * 2
     if not isinstance(splits, Iterable):
         # This might not work if `split` is a tensor.
-        chunk_size = K.int_size(input_0)[axis] // splits
+        chunk_size = input_0.shape[axis] // splits
         splits = (chunk_size,) * splits
     cur = 0
     for i, split in enumerate(splits):
@@ -356,7 +356,7 @@ def convert_split(node, params, layers, lambda_func, node_name, keras_names):
             node_name = params['_outputs'][i]
 
         def target_layer(x, axis=axis, start_i=cur, end_i=cur + split):
-            slices = [slice(None, None)] * len(K.int_shape(x))
+            slices = [slice(None, None)] * len(x.shape)
             slices[axis] = slice(start_i, end_i)
             return x[tuple(slices)]
 
@@ -704,7 +704,7 @@ def convert_trilu(node, params, layers, lambda_func, node_name, keras_name):
     if len(node.input) > 1:
         k_tensor = layers[node.input[1]]
         try:
-            k = int(tf.keras.backend.get_value(k_tensor))
+            k = int(k_tensor.numpy())
         except:
             k = 0  # fallback if symbolic
     upper = params.get("upper", 1)
@@ -912,13 +912,13 @@ def convert_if(node, params, layers, lambda_func, node_name, keras_name):
         else:
             then_lambda = lambda x: in_vec
         lambda_layer = tf.keras.layers.Lambda(then_lambda, name=f"{params['cleaned_name']}_if_serizlize_arr_helper")
-        if not K.is_keras_tensor(cond):
+        if not isinstance(cond, keras.KerasTensor):
             raise NotImplementedError(
                 "We do not support an if where both the then branch and the in-vector are constants")
         then_output = lambda_layer(cond)  # this assumes
     else:
         then_output = outputs[0]
-    layers[node_name] = tf.keras.backend.switch(cond, then_output, outputs[1])
+    layers[node_name] = tf.where(cond, then_output, outputs[1])
 
 
 def convert_einsum(node, params, layers, lambda_func, node_name, keras_name):

--- a/onnx2kerastl/padding_layers.py
+++ b/onnx2kerastl/padding_layers.py
@@ -30,7 +30,7 @@ def convert_padding(node, params, layers, lambda_func, node_name, keras_name):
     else:
         pads = layers[node.input[1]]
 
-    if (is_numpy(pads) or not keras.backend.is_keras_tensor(pads)) and not any(pads):
+    if (is_numpy(pads) or not isinstance(pads, keras.KerasTensor)) and not any(pads):
         layers[node_name] = input_0
         return
 

--- a/onnx2kerastl/pooling_layers.py
+++ b/onnx2kerastl/pooling_layers.py
@@ -8,7 +8,6 @@ import numpy as np
 import string
 import random
 import tensorflow as tf
-import keras.backend as K
 
 
 def convert_maxpool(node, params, layers, lambda_func, node_name, keras_name):
@@ -297,7 +296,7 @@ def convert_topk(node, params, layers, lambda_func, node_name, keras_name):
     to_sort = bool(params.get('sorted', 1))
     x = layers[node.input[0]]
     k = layers[node.input[1]][0]
-    if not is_numpy(k) and not K.is_keras_tensor(k):  # Eager tensor does not serialize well
+    if not is_numpy(k) and not isinstance(k, keras.KerasTensor):  # Eager tensor does not serialize well
         k = k.numpy().astype(np.int32)
     if not largest:
         in_tensor = -x

--- a/onnx2kerastl/reshape_layers.py
+++ b/onnx2kerastl/reshape_layers.py
@@ -3,9 +3,8 @@ import logging
 import keras
 import numpy as np
 import tensorflow as tf
-from keras import backend as K
-from keras.engine.keras_tensor import KerasTensor
-from keras.layers import SlicingOpLambda, Lambda
+from keras import KerasTensor
+from keras.layers import Lambda
 from typing import Union
 from .utils import is_numpy, ensure_tf_type, unsqueeze_tensors_of_rank_one
 from .tfops_funcs import tf_reshape, tf_shape, tf_cast, tf_stack, tf_image_resize, tf_strided_slice,\
@@ -59,7 +58,7 @@ def convert_shape(node, params, layers, lambda_func, node_name, keras_name):
     logger.debug(np.array(input_0.shape))
     is_unknown_tensor = input_0.shape == None
     if not is_unknown_tensor and (
-            not K.is_keras_tensor(input_0) or not any([input_0.shape[i] == None for i in range(len(input_0.shape))])):
+            not isinstance(input_0, keras.KerasTensor) or not any([input_0.shape[i] == None for i in range(len(input_0.shape))])):
         shapes = []
         for i in input_0.shape:
             if i is not None:
@@ -155,7 +154,7 @@ def convert_gather(node, params, layers, lambda_func, node_name, keras_name):
         input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
         if isinstance(layers[node.input[1]], (np.integer, int)) or \
             (not isinstance(layers[node.input[1]], np.ndarray) and \
-                K.is_keras_tensor(layers[node.input[1]])):
+                isinstance(layers[node.input[1]], keras.KerasTensor)):
             #indices are keras tensor or int
             indices = layers[node.input[1]]
         else: #indices are numpy/tf.eager
@@ -201,7 +200,7 @@ def convert_gather(node, params, layers, lambda_func, node_name, keras_name):
             if tf.is_tensor(indices):
                 indices = tf_where(indices < 0, indices + dim_len, indices,
                                    tf_name=f"{params['cleaned_name']}_gather_indices_where")
-            if isinstance(input_0, np.ndarray) or not  K.is_keras_tensor(input_0):
+            if isinstance(input_0, np.ndarray) or not  isinstance(input_0, keras.KerasTensor):
                 if len(input_0) > OPTIMIZE_ARRAY_LENGTH:
                     input_0, indices = optimize_constant_array_for_serialization(input_0, params, indices, logger)
             layers[node_name] = tf_gather(input_0, indices, axis=axis, tf_name=f"{params['cleaned_name']}_gather")
@@ -228,7 +227,7 @@ def convert_concat(node, params, layers, lambda_func, node_name, keras_name):
     else:
         logger.debug('Concat Keras layers.')
         if len(layer_input) > 1:
-            if not np.array([tf.is_tensor(layer_input[i]) and K.is_keras_tensor(layer_input[i]) for i in
+            if not np.array([tf.is_tensor(layer_input[i]) and isinstance(layer_input[i], keras.KerasTensor) for i in
                              range(len(layer_input))]).all() or any(
                 [layer_input[i].shape == None for i in range(len(layer_input))]):
                 try:
@@ -495,7 +494,7 @@ def convert_slice(node, params, layers, lambda_func, node_name, keras_name):
     for i in range(len(starts)):
         for index_li in [starts, steps, ends]:
             if index_li[i] is not None and not isinstance(index_li[i], int) and not is_numpy(
-                    index_li[i]) and K.is_keras_tensor(index_li[i]):
+                    index_li[i]) and isinstance(index_li[i], keras.KerasTensor):
                 is_dynamic = True
     if not is_dynamic:
         for axis in range(max_len):
@@ -512,9 +511,11 @@ def convert_slice(node, params, layers, lambda_func, node_name, keras_name):
             sliced = layers[node.input[0]][start:end:step]
         else:
             input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
-            slicing_layer = SlicingOpLambda(tf.__operators__.getitem)
-            sliced = slicing_layer(input_0, slice_spec=slice_spec_param)
-            if is_numpy(layers[node.input[0]]) and not K.is_keras_tensor(sliced):
+            slice_tuples = tuple(
+                slice(s.get('start'), s.get('stop'), s.get('step')) for s in slice_spec_param
+            )
+            sliced = input_0[slice_tuples]
+            if is_numpy(layers[node.input[0]]) and not isinstance(sliced, keras.KerasTensor):
                 sliced = sliced.numpy()
         layers[node_name] = sliced
     else:

--- a/onnx2kerastl/utils.py
+++ b/onnx2kerastl/utils.py
@@ -2,7 +2,7 @@ from typing import List, Union, Callable
 
 import numpy as np
 import keras
-from keras.engine.keras_tensor import KerasTensor
+from keras import KerasTensor
 from keras_data_format_converter import convert_channels_first_to_last
 import tensorflow as tf
 from.tfops_funcs import tf_reshape

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,15 @@ authors = ["dorhar <doron.harnoy@tensorleap.ai>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.11"
-tensorflow = {version = "2.12.0", markers = "platform_machine  == 'x86_64'"}
-tensorflow-macos = {version = "2.12.0", markers = "platform_machine  == 'arm64'"}
-onnx = "1.13.0"
-protobuf = "^3.19.6"
-tensorflow-addons = {version = "^0.19.0", markers = "platform_machine  == 'x86_64'"}
-numpy = "1.23.5"
+python = ">=3.10, <3.14"
+tensorflow = {version = "^2.21.0", markers = "platform_machine  == 'x86_64'"}
+tensorflow-macos = {version = "^2.21.0", markers = "platform_machine  == 'arm64'"}
+onnx = "^1.21.0"
+protobuf = "^6.31.0"
+numpy = "^2.3.2"
 fvcore = "^0.1.5.post20221221"
 boto3 = "^1.24.22"
-tensorflow-io-gcs-filesystem = "0.34.0"
-keras-data-format-converter = "0.1.24"
+keras-data-format-converter = "^0.1.17"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,13 @@ keras-data-format-converter = "^0.1.17"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
-torch = {version = "1.12.1"}
-torchvision = {version = "^0.12.0"}
+torch = {version = ">=2.0.0"}
+torchvision = {version = "^0.15.0"}
 transformers = {extras = ["onnx"], version = "^4.25.1"}
 pandas = "^2.0.3"
 datasets = "^2.14.1"
 librosa = "^0.10.0.post2"
-onnxruntime = {version = "<=1.17.3"}
+onnxruntime = {version = ">=1.17.0"}
 sentencepiece ={version = "^0.1.96"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.10, <3.14"
-tensorflow = {version = "^2.21.0", markers = "platform_machine  == 'x86_64'"}
-tensorflow-macos = {version = "^2.21.0", markers = "platform_machine  == 'arm64'"}
+tensorflow = "^2.21.0"
 onnx = "^1.21.0"
 protobuf = "^6.31.0"
 numpy = "^2.3.2"


### PR DESCRIPTION
## Summary
- Bump TF 2.12→2.21, ONNX 1.13→1.21, numpy 1.23→2.3, protobuf 3.x→6.x
- Remove unused tensorflow-addons + tensorflow-io-gcs-filesystem
- Migrate all Keras 2 internal APIs to Keras 3 equivalents
- Replace deprecated keras.backend calls with modern alternatives
- CI: Python 3.13, actions v4/v5

## Test plan
- [ ] Run `poetry lock` and verify resolution
- [ ] Run full layer + model test suites on Python 3.13
- [ ] Verify ONNX→Keras conversion produces correct models

🤖 Generated with [Claude Code](https://claude.com/claude-code)