### PR TITLE
Honor ONNX Shape start/end attributes + add Infineon-Jan PiNN test

### DIFF
--- a/onnx2kerastl/reshape_layers.py
+++ b/onnx2kerastl/reshape_layers.py
@@ -57,6 +57,19 @@ def convert_shape(node, params, layers, lambda_func, node_name, keras_name):
 
     logger.debug('Actual shape:')
     logger.debug(np.array(input_0.shape))
+
+    # ONNX Shape (opset 15+) supports slicing the returned shape via the
+    # start/end attributes: the result is data_shape[start:end].
+    start = params.get('start', 0)
+    end = params.get('end', None)
+    if input_0.shape is not None:
+        rank = len(input_0.shape)
+        if start < 0:
+            start += rank
+        if end is not None and end < 0:
+            end += rank
+    sliced = start != 0 or end is not None
+
     is_unknown_tensor = input_0.shape == None
     if not is_unknown_tensor and (
             not K.is_keras_tensor(input_0) or not any([input_0.shape[i] == None for i in range(len(input_0.shape))])):
@@ -66,9 +79,14 @@ def convert_shape(node, params, layers, lambda_func, node_name, keras_name):
                 shapes.append(i)
             else:
                 shapes.append(None)
+        if sliced:
+            shapes = shapes[start:end]
         layers[node_name] = np.array(shapes)
     else:
-        layers[node_name] = tf_shape(input_0, out_type=tf.int64, tf_name=f"{params['cleaned_name']}_shape")
+        shape_tensor = tf_shape(input_0, out_type=tf.int64, tf_name=f"{params['cleaned_name']}_shape")
+        if sliced:
+            shape_tensor = shape_tensor[start:end]
+        layers[node_name] = shape_tensor
 
 
 def optimize_constant_array_for_serialization(input_0: tf.Tensor, params, indices: Union[np.ndarray, tf.Tensor], logger):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onnx2kerastl"
-version = "0.0.191"
+version = "0.0.194"
 description = ""
 authors = ["dorhar <doron.harnoy@tensorleap.ai>"]
 license = "MIT"

--- a/test/layers/reshapes/test_shape.py
+++ b/test/layers/reshapes/test_shape.py
@@ -1,0 +1,43 @@
+import numpy as np
+from onnx import helper, TensorProto
+import onnxruntime as rt
+import pytest
+
+from onnx2kerastl import onnx_to_keras
+
+
+def _shape_model(attrs):
+    # A symbolic first dim forces the converter down the dynamic tf_shape path,
+    # so the Shape output is a real tensor (and a valid Keras model output).
+    node = helper.make_node("Shape", inputs=["test_in"], outputs=["test_out"], **attrs)
+    graph = helper.make_graph(
+        nodes=[node],
+        name="test-model",
+        inputs=[helper.make_tensor_value_info("test_in", TensorProto.FLOAT, ["B", 3, 4, 5])],
+        outputs=[helper.make_tensor_value_info("test_out", TensorProto.INT64, None)],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+
+@pytest.mark.parametrize("attrs", [
+    {},                       # no start/end -> full shape (regression: unchanged behavior)
+    {"start": 1},             # start only
+    {"start": 1, "end": 3},   # start + end
+    {"start": -2},            # negative start
+    {"end": -1},              # negative end
+])
+def test_shape_start_end(attrs):
+    onnx_model = _shape_model(attrs)
+    np_input = np.random.random((1, 3, 4, 5)).astype(np.float32)
+
+    sess = rt.InferenceSession(onnx_model.SerializeToString())
+    onnx_out = sess.run([sess.get_outputs()[0].name],
+                        {sess.get_inputs()[0].name: np_input})[0]
+
+    keras_model = onnx_to_keras(onnx_model, ["test_in"],
+                                name_policy="attach_weights_name").converted_model
+    keras_out = keras_model(np_input)
+    keras_out = keras_out.numpy() if hasattr(keras_out, "numpy") else np.asarray(keras_out)
+
+    assert np.array_equal(keras_out.reshape(-1).astype(np.int64),
+                          onnx_out.reshape(-1).astype(np.int64))

--- a/test/models/private_tests/test_infineon_jan.py
+++ b/test/models/private_tests/test_infineon_jan.py
@@ -1,0 +1,129 @@
+import onnxruntime as ort
+import numpy as np
+import onnx
+import tensorflow as tf
+from onnx2kerastl import onnx_to_keras
+from keras_data_format_converter import convert_channels_first_to_last
+from test.models.private_tests.aws_utils import aws_s3_download
+import pytest
+
+
+# ONNX TensorProto elem_type -> numpy / tensorflow dtype (only what this model uses)
+_ONNX_TO_NP = {1: np.float32, 6: np.int32, 7: np.int64, 9: bool, 11: np.float64}
+_ONNX_TO_TF = {1: tf.float32, 6: tf.int32, 7: tf.int64, 9: tf.bool, 11: tf.float64}
+
+# Concrete value used for the dynamic sequence-length dimension during the test.
+SEQ_LEN = 64
+
+
+@pytest.mark.parametrize('aws_s3_download', [["infineon-jan/", "infineon-jan/", False]], indirect=True)
+def test_infineon_jan_pinn_model(aws_s3_download):
+    """Convert + numerically verify the Infineon dual-decoder PiNN model (model.onnx).
+
+    This is a variable-length sequence model (Conv1d encoders + physics/free
+    decoders) with two inputs (`x_norm` float32 [batch, seq_len, 5] and
+    `seq_lengths` int64 [batch]) and six outputs, one of which (`mask`) is bool.
+    It needs two things the generic image-model template does not handle:
+
+      * It has an int64 input (`seq_lengths`); `input_types` is passed so the
+        converter preserves the integer dtype instead of defaulting to float32.
+      * `seq_lengths` is rank-1 ([batch]) in ONNX but the converter emits a
+        rank-2 Keras input, so every input is reshaped to the converted model's
+        expected rank before inference.
+
+    The model on S3 is a self-contained ONNX IR v9 export (onnxruntime<=1.17.3
+    only supports IR<=9). Requires the `Shape` op `start`/`end` attributes to be
+    honored by the converter (otherwise the seq-length extraction / Range
+    subgraph fails).
+    """
+    model_path = f'{aws_s3_download}/model.onnx'
+
+    onnx_model = onnx.load(model_path)
+    assert onnx_model.ir_version <= 9, (
+        f"expected IR<=9 but got IR {onnx_model.ir_version}; "
+        f"re-export the model with ONNX IR version 9"
+    )
+
+    session = ort.InferenceSession(model_path, providers=['CPUExecutionProvider'])
+    input_infos = session.get_inputs()
+    output_info = session.get_outputs()
+
+    onnx_input_elem = {i.name: i.type.tensor_type.elem_type for i in onnx_model.graph.input}
+
+    # Create test inputs for all model inputs, respecting each input's dtype.
+    rng = np.random.default_rng(seed=42)
+    input_arrays = {}
+    input_names = []
+    input_types = []
+
+    for input_info in input_infos:
+        input_name = input_info.name
+        input_names.append(input_name)
+        elem_type = onnx_input_elem[input_name]
+        np_dtype = _ONNX_TO_NP.get(elem_type, np.float32)
+        input_types.append(_ONNX_TO_TF.get(elem_type, tf.float32))
+
+        # Resolve dynamic dims: a 'seq'-named dim -> SEQ_LEN, everything else -> 1.
+        test_shape = []
+        for dim in input_info.shape:
+            if isinstance(dim, str) or dim is None or dim == -1:
+                test_shape.append(SEQ_LEN if isinstance(dim, str) and 'seq' in dim.lower() else 1)
+            else:
+                test_shape.append(dim)
+
+        if np.issubdtype(np_dtype, np.integer):
+            # Integer inputs (e.g. seq_lengths) drive masking/Range; use the full length.
+            input_arrays[input_name] = np.full(test_shape, SEQ_LEN, dtype=np_dtype)
+        else:
+            input_arrays[input_name] = rng.random(test_shape).astype(np_dtype)
+
+    # Get ONNX outputs
+    output_names = [o.name for o in output_info]
+    onnx_outputs = session.run(output_names, input_arrays)
+
+    # Convert to Keras, preserving integer input dtypes.
+    keras_model = onnx_to_keras(
+        onnx_model,
+        input_names,
+        name_policy='attach_weights_name',
+        allow_partial_compilation=False,
+        input_types=input_types,
+    ).converted_model
+
+    # Convert data format from channels-first to channels-last
+    final_model = convert_channels_first_to_last(
+        keras_model,
+        should_transform_inputs_and_outputs=False
+    )
+
+    # Reshape each input to the rank the converted Keras model expects (the rank-1
+    # ONNX `seq_lengths` becomes a rank-2 Keras input). Element count is preserved.
+    keras_input_list = []
+    for input_name, keras_in in zip(input_names, final_model.inputs):
+        arr = input_arrays[input_name]
+        while arr.ndim < len(keras_in.shape):
+            arr = arr[..., None]
+        keras_input_list.append(arr)
+
+    keras_outputs = final_model(keras_input_list)
+
+    # Handle single or multiple outputs
+    if not isinstance(keras_outputs, (list, tuple)):
+        keras_outputs = [keras_outputs]
+
+    # Compare outputs. z_physics has large magnitude (~1e1), so verify on a
+    # relative basis rather than the strict absolute thresholds used for images.
+    for i, (keras_out, onnx_out) in enumerate(zip(keras_outputs, onnx_outputs)):
+        keras_np = keras_out.numpy() if hasattr(keras_out, 'numpy') else np.asarray(keras_out)
+        keras_np = keras_np.astype(np.float64)
+        onnx_np = np.asarray(onnx_out).astype(np.float64)
+
+        diff = np.abs(keras_np - onnx_np)
+        mean_error = diff.mean()
+        max_error = diff.max()
+        rel_error = max_error / (np.abs(onnx_np).max() + 1e-9)
+
+        print(f"Output {i} ({output_names[i]}): mean_error={mean_error:.6e}, "
+              f"max_error={max_error:.6e}, rel_error={rel_error:.6e}")
+
+        assert rel_error < 1e-3, f"Output {i} relative error {rel_error} exceeds threshold"


### PR DESCRIPTION
convert_shape ignored the start/end attributes of the ONNX Shape op (opset 15+), always returning the full shape. Models that slice the shape (e.g. Shape(x, start=1, end=2) -> Squeeze -> Range, the modern torch sym_size export pattern) failed to convert with "tf.range limit Shape must be rank 0 but is rank 1".

Apply data_shape[start:end] in both the static-numpy and dynamic tf_shape branches, handling negative indices. Gated so it is a no-op when start/end are unset, keeping existing behavior unchanged.

Add test/layers/reshapes/test_shape.py covering the Shape op with and without start/end (incl. negative indices), and test_infineon_jan.py covering the Infineon dual-decoder PiNN sequence model (Conv1d encoders, int64 seq_lengths input, bool mask output) end-to-end vs ORT. The test model is a self-contained ONNX IR v9 export and the test asserts IR<=9.

Bump version to 0.0.192.