### PR TITLE
Fix ScatterND constant embedding via concrete tensor bypass

### DIFF
--- a/onnx2kerastl/utils.py
+++ b/onnx2kerastl/utils.py
@@ -64,7 +64,16 @@ def big_constant_to_graph_tensor(value, name="Const"):
     Only used at genuine graph-entry points. Constants that are consumed as
     layer weights or that participate in constant folding must NOT go through
     here - they need to stay numpy (see ``ensure_tf_type``).
+
+    ``value`` can also be a concrete (eager) tf.Tensor rather than a numpy
+    array: helper converters (e.g. Where/Equal/Mul/Expand) call real tf ops
+    even when every input is a numpy constant, and under eager execution
+    that always returns an EagerTensor -- a fully materialized value just
+    like a numpy array, but not caught by ``is_numpy``. Coerce it first so
+    the same size-based protection still applies.
     """
+    if tf.is_tensor(value) and not isinstance(value, KerasTensor):
+        value = value.numpy()
     if _constant_anchor is not None and is_numpy(value) and value.size > LARGE_CONSTANT_THRESHOLD:
         from .customonnxlayer.onnxconstant import OnnxConstant
         return OnnxConstant(value=value, name=name)(_constant_anchor)


### PR DESCRIPTION
## Summary
- `big_constant_to_graph_tensor()` only recognized `numpy.ndarray` as needing the `OnnxConstant` weight-storage protection. Helper converters (`Where`/`Equal`/`Mul`/`Expand`/`Concat`) call real `tf.*` ops even when every input is a numpy constant, and under eager execution that returns an `EagerTensor` instead of a numpy array -- so `is_numpy()` missed it and the value got baked inline into the layer's `inbound_nodes` as a literal, uncapped Python list.
- On the OmniVLA model this produced a single ScatterND `indices` tensor (`[1,1,567,567,4]`) getting embedded ~964k times across the graph (413B elements total), causing `get_config()`/`to_json()`/`model.save()` to hang for 30+ minutes or OOM.
- Same root-cause class as the BEVFusion ScatterND/GatherElements issue fixed in #226, just reached through a different operand type.

## Fix
Coerce concrete (non-symbolic) `tf.Tensor` values to numpy before the existing size check, so the same size-based `OnnxConstant` protection applies regardless of whether the constant arrived as a numpy array or an already-materialized eager tensor.

## Verification
Ran the real conversion pipeline end to end on the OmniVLA model (onnx_to_keras -> channel convert -> save -> inference):
- Embedded constant elements: 413,422,637,613 -> 331,927
- `json.dumps()` on the model config: never completed (30+ min / OOM) -> 0.79s
- Numeric output vs PyTorch ground truth: unchanged (max abs diff 7.152557373046875e-06, identical to baseline)
